### PR TITLE
Allow user to specify different flags for queue and push strings rather than Buffer objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,11 +103,13 @@ Methods
     * maxmsgs - _integer_ - If creating a queue, this is the maximum number of messages the queue can hold. This value is subject to the system limits in place and defaults to 10.
 
     * msgsize - _integer_ - If creating a queue, this is the maximum size of each message (in bytes) in the queue. This value is subject to the system limits in place and defaults to 8192 bytes.
+
+    * flags - _integer_ - Default is `O_RDWR | O_NONBLOCK` (2050). If a different flags value is required, its integer value may be provided here.
     
 * **close**() - _(void)_ - Disconnects from the queue.
 
 * **unlink**() - _(void)_ - Removes the queue from the system.
 
-* **push**(< _Buffer_ >data[, < _integer_ >priority]) - _boolean_ - Pushes a message with the contents of `data` onto the queue with the optional `priority` (defaults to 0). `priority` is an integer between 0 and 31 inclusive.
+* **push**(< _Buffer_ or _string_ >data[, < _integer_ >priority]) - _boolean_ - Pushes a message with the contents of `data` onto the queue with the optional `priority` (defaults to 0). `data` is either a string or Buffer object. `priority` is an integer between 0 and 31 inclusive.
 
 * **shift**(< _Buffer_ >readbuf[, < _boolean_ >returnTuple]) - _mixed_ - Shifts the next message off the queue and stores it in `readbuf`. If `returnTuple` is set to true, an array containing the number of bytes in the shifted message and the message's priority are returned, otherwise just the number of bytes is returned (default). If there was nothing on the queue, false is returned.

--- a/src/posixmq.cc
+++ b/src/posixmq.cc
@@ -107,6 +107,13 @@ class PosixMQ : public ObjectWrap {
         doCreate = val->BooleanValue();
       }
 
+      if (!(val = config->Get(String::New("flags")))->IsUndefined()) {
+        if (val == String::New("read_only"))
+            flags = O_RDONLY | O_NONBLOCK;
+        else if (val == String::New("write_only"))
+            flags = O_WRONLY | O_NONBLOCK;
+      }
+
       val = config->Get(String::New("name"));
       if (!val->IsString()) {
         return ThrowException(Exception::TypeError(

--- a/src/posixmq.cc
+++ b/src/posixmq.cc
@@ -108,10 +108,12 @@ class PosixMQ : public ObjectWrap {
       }
 
       if (!(val = config->Get(String::New("flags")))->IsUndefined()) {
-        if (val == String::New("read_only"))
-            flags = O_RDONLY | O_NONBLOCK;
-        else if (val == String::New("write_only"))
-            flags = O_WRONLY | O_NONBLOCK;
+        if (val->IsUint32())
+            flags = val->Uint32Value();
+        else {
+            return ThrowException(Exception::TypeError(
+                String::New("'flags' property must be an int")));
+        }
       }
 
       val = config->Get(String::New("name"));
@@ -271,14 +273,15 @@ class PosixMQ : public ObjectWrap {
       HandleScope scope;
       PosixMQ* obj = ObjectWrap::Unwrap<PosixMQ>(args.This());
       uint32_t priority = 0;
+      int send_result;
       bool ret = true;
 
       if (args.Length() < 1) {
         return ThrowException(Exception::TypeError(
             String::New("Expected at least 1 argument")));
-      } else if (!Buffer::HasInstance(args[0])) {
+      } else if ((!Buffer::HasInstance(args[0])) and (!args[0]->IsString())) {
         return ThrowException(Exception::TypeError(
-            String::New("First argument must be a Buffer")));
+            String::New("First argument must be a Buffer or String")));
       } else if (args.Length() >= 2) {
         if (args[1]->IsUint32() && args[1]->Uint32Value() < 32)
           priority = args[1]->Uint32Value();
@@ -288,8 +291,22 @@ class PosixMQ : public ObjectWrap {
         }
       }
 
-      if (mq_send(obj->mqdes, Buffer::Data(args[0]->ToObject()),
-                  Buffer::Length(args[0]->ToObject()), priority) == -1) {
+      if (Buffer::HasInstance(args[0])) {
+          send_result = mq_send(obj->mqdes, Buffer::Data(args[0]->ToObject()),
+                                Buffer::Length(args[0]->ToObject()), priority);
+      }
+      else if (args[0]->IsString()) {
+          const char* message;
+          String::AsciiValue msgstr(args[0]->ToString());
+          message = (const char*)(*msgstr);
+          send_result = mq_send(obj->mqdes, message, strlen(message), priority);
+      }
+      else {
+        return ThrowException(Exception::TypeError(
+            String::New("First argument wasn't a Buffer or String!")));
+      }
+
+      if (send_result == -1) {
         if (errno != EAGAIN) {
           return ThrowException(Exception::Error(
               String::New(uv_strerror(uv_last_error(uv_default_loop())))));


### PR DESCRIPTION
When calling `mq.open()`, a user may now specify an integer flag to pass through to the call to `mq_open()`. This is useful if the queue must be opened readonly or writeonly.

Example:

``` javascript
var PosixMQ = require('pmq');
mq = new PosixMQ();
mq.open({name: '/pmqtest', flags: 2049});  // O_WRONLY | O_NONBLOCK
```

---

The user may also now choose to push a string without first converting it to a Buffer object.

Example:

``` javascript
var writebuf = new Buffer("Message to push");
mq.push(writebuf);
```

or

``` javascript
mq.push("Message to push");
```
